### PR TITLE
Support for simple codetabs and tabs

### DIFF
--- a/DocuCheck.xcodeproj/project.pbxproj
+++ b/DocuCheck.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		BF8494C024E6900100340D59 /* BuildCodeTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8494BE24E68FEB00340D59 /* BuildCodeTabs.swift */; };
 		OBJ_100 /* Cmd.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* Cmd.swift */; };
 		OBJ_101 /* CommandArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* CommandArguments.swift */; };
 		OBJ_102 /* Console.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* Console.swift */; };
@@ -86,6 +87,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BF8494BE24E68FEB00340D59 /* BuildCodeTabs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildCodeTabs.swift; sourceTree = "<group>"; };
 		"DocuCheck::DocuCheck::Product" /* DocuCheck */ = {isa = PBXFileReference; lastKnownFileType = text; path = DocuCheck; sourceTree = BUILT_PRODUCTS_DIR; };
 		"DocuCheck::DocuCheckLib::Product" /* DocuCheckLib.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = DocuCheckLib.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"DocuCheck::DocuCheckTests::Product" /* DocuCheckTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = DocuCheckTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -189,6 +191,7 @@
 		OBJ_12 /* DatabaseOperations */ = {
 			isa = PBXGroup;
 			children = (
+				BF8494BE24E68FEB00340D59 /* BuildCodeTabs.swift */,
 				OBJ_13 /* LinkStatistics.swift */,
 				OBJ_14 /* PatchSingleFileDocumentation.swift */,
 				OBJ_15 /* RemoveUnwantedSections.swift */,
@@ -264,7 +267,7 @@
 			path = Tests/DocuCheckTests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -276,7 +279,6 @@
 				OBJ_59 /* LICENSE */,
 				OBJ_60 /* README.md */,
 			);
-			name = "";
 			sourceTree = "<group>";
 			usesTabs = 0;
 		};
@@ -391,7 +393,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_53 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -439,6 +441,7 @@
 				OBJ_75 /* LinkStatistics.swift in Sources */,
 				OBJ_76 /* PatchSingleFileDocumentation.swift in Sources */,
 				OBJ_77 /* RemoveUnwantedSections.swift in Sources */,
+				BF8494C024E6900100340D59 /* BuildCodeTabs.swift in Sources */,
 				OBJ_78 /* SaveAllDocuments.swift in Sources */,
 				OBJ_79 /* UpdateDocumentTitles.swift in Sources */,
 				OBJ_80 /* UpdateRepositoryLinks.swift in Sources */,

--- a/Sources/DocuCheckLib/Application/DatabaseOperations/BuildCodeTabs.swift
+++ b/Sources/DocuCheckLib/Application/DatabaseOperations/BuildCodeTabs.swift
@@ -1,0 +1,201 @@
+//
+// Copyright 2020 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+
+import Foundation
+
+extension DocumentationDatabase {
+    
+    
+    /// Transform all `codetabs` or `tabs` metadata objects in all documents.
+    /// - Returns: true if everyghing was OK.
+    func updatedCodeTabs() -> Bool {
+        var result = true
+        allDocuments().forEach { document in
+            // Process all <!-- begin codetabs ... --> metadata objects
+            document.allMetadata(withName: "codetabs", multiline: true).forEach { metadata in
+                let partialResult = self.updateCodeTabs(document: document, metadata: metadata)
+                result = result && partialResult
+            }
+            // Find all <!-- tab name --> metadata objects and create map with inline identifiers.
+            let allTabMarkers: [EntityId:MarkdownMetadata] = document.allMetadata(withName: "tab", multiline: false).reduce(into: [:]) { $0[$1.beginInlineCommentId] = $1 }
+            // Process all <!-- begin tabs --> metadata objects
+            document.allMetadata(withName: "tabs", multiline: true).forEach { metadata in
+                let partialResult = self.updateTabs(document: document, metadata: metadata, tabMarkers: allTabMarkers)
+                result = result && partialResult
+            }
+        }
+        return result
+    }
+    
+    
+    /// Transform `<!-- begin codetabs -->` metadata into `{% codetabs %}`.
+    /// - Parameters:
+    ///   - document: Current document
+    ///   - metadata: Metadata object contains codetabs.
+    /// - Returns: true in case of success.
+    private func updateCodeTabs(document: MarkdownDocument, metadata: MarkdownMetadata) -> Bool {
+
+        let tabNames = metadata.parameters ?? []
+        if tabNames.isEmpty {
+            Console.warning(document, metadata.beginLine, "'\(metadata.name)' marker has no tab names specified.")
+        }
+
+        // Acquire all lines
+        guard let oldLines = document.getLinesForMetadata(metadata: metadata, includeMarkers: false, removeLines: false) else {
+            Console.error(document, metadata.beginLine, "updateCodeTabs: Failed to acquire lines for '\(metadata.name)' metadata marker.")
+            return false
+        }
+        var codeBlocks = [[MarkdownLine]]()
+        var currentBlock = [MarkdownLine]()
+        var isInCodeBlock = false
+        for line in oldLines {
+            let isCodeBlockAtEnd = line.parserStateAtEnd.isCodeBlock
+            currentBlock.append(line)
+            if isInCodeBlock != isCodeBlockAtEnd {
+                // State has changed for this line
+                if !isCodeBlockAtEnd {
+                    codeBlocks.append(currentBlock)
+                    currentBlock.removeAll()
+                }
+                isInCodeBlock = isCodeBlockAtEnd
+            }
+        }
+        if !currentBlock.isEmpty {
+            codeBlocks.append(currentBlock)
+        }
+
+        return applyCodeTabs(document: document, metadata: metadata, tabNames: tabNames, tabContent: codeBlocks)
+    }
+    
+    
+    /// Transform `<!-- begin tabs -->` metadata into `{% codetabs %}`.
+    /// - Parameters:
+    ///   - document: Document
+    ///   - metadata: Metadata object
+    ///   - tabMarkers: Dictionary with mapping from entity identifier to `<!-- tab -->` metadata object
+    /// - Returns: true in case of success.
+    private func updateTabs(document: MarkdownDocument, metadata: MarkdownMetadata, tabMarkers: [EntityId:MarkdownMetadata]) -> Bool {
+        
+        // Acquire all lines
+        guard let oldLines = document.getLinesForMetadata(metadata: metadata, includeMarkers: false, removeLines: false) else {
+            Console.error(document, metadata.beginLine, "updateTabs: Failed to acquire lines for '\(metadata.name)' metadata marker.")
+            return false
+        }
+        
+        var tabNames = [String]()
+        var tabBlocks = [[MarkdownLine]]()
+        var currentBlock = [MarkdownLine]()
+        
+        for line in oldLines {
+            let copyLine: Bool
+            if let tabMetadata = findTabInLine(line: line, tabMarkers: tabMarkers) {
+                // It's also "tab" metadata marker
+                if let tabName = tabMetadata.parameters?.first {
+                    tabNames.append(tabName)
+                } else {
+                    Console.warning(document, tabMetadata.beginLine, "'\(tabMetadata.name)' marker must contain tab name. Using placeholder name.")
+                    tabNames.append("Tab_\(tabNames.count + 1)")
+                }
+                if !currentBlock.isEmpty {
+                    tabBlocks.append(currentBlock)
+                    currentBlock.removeAll()
+                }
+                copyLine = false
+            } else {
+                // Unknown inline comment, just copy this line
+                copyLine = true
+            }
+            if copyLine {
+                if !tabNames.isEmpty {
+                    currentBlock.append(line)
+                } else {
+                    Console.warning(document, line.identifier, "'\(metadata.name)' marker contains lines without tab name specified. Use '<!-- tab NAME -->' before this content.")
+                }
+            }
+        }
+        if !currentBlock.isEmpty {
+            tabBlocks.append(currentBlock)
+        }
+        return applyCodeTabs(document: document, metadata: metadata, tabNames: tabNames, tabContent: tabBlocks)
+    }
+    
+    
+    /// Find metadata object matching one of inline comments available in the line.
+    /// - Parameters:
+    ///   - line: Line containing inline comments.
+    ///   - tabMarkers: All tab metadata objects.
+    /// - Returns: Metadata object or nil if no such object has been matched.
+    private func findTabInLine(line: MarkdownLine, tabMarkers: [EntityId:MarkdownMetadata]) -> MarkdownMetadata? {
+        for comment in line.allEntities(withType: .inlineComment) {
+            if let metadata = tabMarkers[comment.identifier] {
+                return metadata
+            }
+        }
+        return nil
+    }
+    
+    
+    /// Apply `codetabs` or `tabs` changes to the document.
+    /// - Parameters:
+    ///   - document: Current document
+    ///   - metadata: Metadata object containing `codetabs` or `tabs`
+    ///   - names: Tab names
+    ///   - tabContent: Content of tabs.
+    /// - Returns: true in case of success.
+    private func applyCodeTabs(document: MarkdownDocument, metadata: MarkdownMetadata, tabNames names: [String], tabContent: [[MarkdownLine]]) -> Bool {
+        
+        var tabNames = names
+        
+        if tabContent.count != tabNames.count {
+            if tabContent.count > tabNames.count {
+                Console.warning(document, metadata.beginLine, "'\(metadata.name)' meta tag contains more code blocks than tab names. Using placeholder names.")
+                tabNames.append(contentsOf: (tabNames.count...tabContent.count).map { "Tab_\($0)" })
+            } else {
+                Console.warning(document, metadata.beginLine, "'\(metadata.name)' meta tag contains less code blocks than tab names. Ignoring remaining tab names.")
+            }
+        }
+        
+        // Prepare markers
+        let codeTabsMarkers = document.prepareLinesForAdd(lines: ["{% codetabs %}", "{% endcodetabs %}"])
+        let partialTabsMarkers = document.prepareLinesForAdd(lines: tabNames.flatMap { tabName -> [String] in
+            return [ "{% codetab \(tabName) %}", "{% endcodetab %}" ]
+        })
+        var newLines = [MarkdownLine]()
+        
+        // Leading marker
+        newLines.append(codeTabsMarkers[0])
+        
+        for (index, codeBlock) in tabContent.enumerated() {
+            newLines.append(partialTabsMarkers[index * 2])      // {% codetab XX %}
+            newLines.append(contentsOf: codeBlock)              // code block lines
+            newLines.append(partialTabsMarkers[index * 2 + 1])  // {% codetab XX %}
+        }
+
+        // Trailing marker
+        newLines.append(codeTabsMarkers[1])
+        
+        // Make modifications in document
+        guard let startLine = document.lineNumber(forLineIdentifier: metadata.beginLine) else {
+            Console.error(document, metadata.beginLine, "applyCodeTabs: Failed to acquire start line number.")
+            return false
+        }
+        
+        document.removeLinesForMetadata(metadata: metadata, includeMarkers: true)
+        document.add(lines: newLines, at: startLine)
+        
+        return true
+    }
+}

--- a/Sources/DocuCheckLib/Application/DatabaseOperations/RemoveUnwantedSections.swift
+++ b/Sources/DocuCheckLib/Application/DatabaseOperations/RemoveUnwantedSections.swift
@@ -25,7 +25,7 @@ extension DocumentationDatabase {
     /// - Returns: true if operation succeeds
     func removeUnwantedSections() -> Bool {
         allDocuments().forEach { document in
-            document.allMetadata(withName: "remove").forEach { metadata in
+            document.allMetadata(withName: "remove", multiline: true).forEach { metadata in
                 document.removeLinesForMetadata(metadata: metadata)
             }
         }

--- a/Sources/DocuCheckLib/Application/DocuCheckApplication.swift
+++ b/Sources/DocuCheckLib/Application/DocuCheckApplication.swift
@@ -166,6 +166,7 @@ public class DocuCheckApplication {
         
         _ = database.patchSingleFileDocumentation()
         _ = database.removeUnwantedSections()
+        _ = database.updatedCodeTabs()
         _ = database.updateRepositoryLinks()
         _ = database.updateDocumentTitles()
         _ = database.saveAllChanges()

--- a/Sources/DocuCheckLib/Markdown/MarkdownLine.swift
+++ b/Sources/DocuCheckLib/Markdown/MarkdownLine.swift
@@ -28,8 +28,8 @@ class MarkdownLine {
     /// Entities found in the line
     var entities = [MarkdownEditableEntity]()
      
-    /// Contains parser's state at the end of line
-    var parserStateAtStart = MarkdownParserState.none
+    /// Contains parser's state at the begin of line
+    var parserStateAtBegin = MarkdownParserState.none
 
     /// Contains parser's state at the end of line
     var parserStateAtEnd = MarkdownParserState.none
@@ -72,7 +72,7 @@ extension MarkdownLine {
         return entities.first { $0.identifier == entityId }
     }
     
-    /// Adds entity to the line
+    /// Adds entity to the line.
     ///
     /// - Parameter entity: entity to be added
     func add(entity: MarkdownEditableEntity) {
@@ -86,7 +86,7 @@ extension MarkdownLine {
         entities.append(entity)
     }
     
-    /// Removes entity with identifier
+    /// Removes entity with identifier.
     ///
     /// - Parameter entityId: Identifier of entity to be removed
     func remove(entityId: EntityId) {
@@ -96,19 +96,35 @@ extension MarkdownLine {
         entities.remove(at: index)
     }
     
-    /// Removes entity from the line
+    /// Removes entity from the line.
     ///
     /// - Parameter entity: Entity to be removed from the line
     func remove(entity: MarkdownEntity) {
         remove(entityId: entity.identifier)
     }
     
-    /// Returns true if line contains entity with given identifier
+    /// Returns true if line contains entity with given identifier.
     ///
     /// - Parameter entityId: Entity to be found
     /// - Returns: true, if line contains entity with given identifier.
     func contains(entityId: EntityId) -> Bool {
         return entities.firstIndex(where: { $0.identifier == entityId }) != nil
+    }
+    
+    /// Returns true if line contains entity with given type
+    ///
+    /// - Parameter entityType: Entity with type to be found
+    /// - Returns: true, if line contains entity with given type.
+    func contains(entityType: EntityType) -> Bool {
+        return entities.firstIndex(where: { $0.type == entityType }) != nil
+    }
+    
+    
+    /// Return all entities with given type.
+    /// - Parameter type: Entity type
+    /// - Returns: Entities with requested type, or empty array if line contains no such object.
+    func allEntities(withType type: EntityType) -> [MarkdownEditableEntity] {
+        return entities.filter { $0.type ==  type }
     }
 }
 

--- a/Sources/DocuCheckLib/Markdown/MarkdownMetadata.swift
+++ b/Sources/DocuCheckLib/Markdown/MarkdownMetadata.swift
@@ -31,6 +31,12 @@ struct MarkdownMetadata {
     /// Line identifier where metadata information ends
     let endLine: EntityId
     
+    /// Inline comment entity identifier where metadata information begins
+    let beginInlineCommentId: EntityId
+    
+    /// Inline comment entity identifier where metadata information ends.
+    let endInlineCommentId: EntityId
+    
     /// Contains true if metadata information is stored at multiple lines
     var isMultiline: Bool {
         return beginLine != endLine

--- a/Sources/DocuCheckLib/Markdown/MarkdownParser.swift
+++ b/Sources/DocuCheckLib/Markdown/MarkdownParser.swift
@@ -132,7 +132,7 @@ class MarkdownParser {
     private func parseLine(_ line: MarkdownLine, initialState: MarkdownParserState) -> MarkdownParserState {
         var state = initialState
         
-        line.parserStateAtStart = state
+        line.parserStateAtBegin = state
         
         var nextValidOffset: Int?
         let lc = line.lineContent

--- a/docs/Basic-Principles.md
+++ b/docs/Basic-Principles.md
@@ -176,4 +176,40 @@ In case you would like to include a custom sidebar in the document, you can do s
 
 The first parameter defines a name of the file to include (in the same folder as the main document). The second parameter defines the sidebar position - `sticky` means that the sidebar should remain visible, any other value (or empty parameter) means that the sidebar scrolls with the content. Use `sticky` value with caution for reasonably small sidebars - if the sidebar is too high, content may not be reachable.
 
+#### Code tabs
 
+You can format code examples written in different languages into tabs, that user can switch between. For example, let say, you want to write the same example in Swift and Objective-C code:
+
+~~~md
+<!-- begin codetabs Swift Objective-C -->
+```swift
+// Example in Swift
+let object = Object()
+```
+```objc
+// Example in Objective-C
+NSObject * object = [[NSObject alloc] init];
+```
+<!-- end -->
+~~~
+
+The number of parameters used in `codetabs`  defines the number of tabs visible in the final documentation. Make sure that the number of code blocks match the number of tab names and there's no other markdown formatting between the code blocks.
+
+#### Arbitrary tabs
+
+In case that [code tabs](#code-tabs) doesn't fit your formatting requirements, then use  `tabs` metadata marker and specify each tab with `tab`. For example:
+
+~~~md
+<!-- begin tabs -->
+<!-- tab Swift -->
+Use following code for swift:
+```swift
+let object = Object()
+```
+<!-- tab Objective-C -->
+Use following code for Objective-C:
+```objc
+NSObject * object = [[NSObject alloc] init];
+```
+<!-- end -->
+~~~


### PR DESCRIPTION
This PR adds a support for `<-- begin codetabs X Y -->` and `<!-- begin tabs -->` / `<!-- tab NAME -->` metadata markers.