### PR TITLE
Support for easy documentation testing

### DIFF
--- a/Sources/DocuCheckLib/Application/DatabaseOperations/BuildCodeTabs.swift
+++ b/Sources/DocuCheckLib/Application/DatabaseOperations/BuildCodeTabs.swift
@@ -22,6 +22,7 @@ extension DocumentationDatabase {
     /// Transform all `codetabs` or `tabs` metadata objects in all documents.
     /// - Returns: true if everyghing was OK.
     func updatedCodeTabs() -> Bool {
+        Console.info("Building code tabs...")
         var result = true
         allDocuments().forEach { document in
             // Process all <!-- begin codetabs ... --> metadata objects

--- a/Sources/DocuCheckLib/Application/DatabaseOperations/PatchSingleFileDocumentation.swift
+++ b/Sources/DocuCheckLib/Application/DatabaseOperations/PatchSingleFileDocumentation.swift
@@ -23,6 +23,7 @@ extension DocumentationDatabase {
     ///
     /// - Returns: true if operation succeeded
     func patchSingleFileDocumentation() -> Bool {
+        Console.info("Patching single docs...")
         repositories.forEach { repoId, repo in
             if repoId.contains("/") {
                 return

--- a/Sources/DocuCheckLib/Config/Config.swift
+++ b/Sources/DocuCheckLib/Config/Config.swift
@@ -150,15 +150,32 @@ struct Config: Decodable {
 
 
 extension Config {
+
+    /// Returns full path to the repository, based on provided 'basePath'. Unlike `sourcesPath()` function, this
+    /// variant doesn't follow `localFiles` configuration option.
+    ///
+    /// - Parameter identifier: Identifier of repository (e.g. key to "parameters" configuration)
+    /// - Parameter basePath: Base path to calculate a full path.
+    /// - Returns: String with a full path to requested repository
+    func path(repo identifier: String, basePath: String) -> String {
+        guard let repo = repositories[identifier] else {
+            Console.fatalError("Unknown repository identifier `\(identifier)`.")
+        }
+        return basePath.addingPathComponent(repo.path ?? identifier)
+    }
     
-    /// Returns relative path where the repository with given identifier was cloned.
+    /// Returns path where the repository with given identifier was cloned.
     ///
     /// - Parameter identifier: Identifier of repository (e.g. key to "parameters" configuration)
     /// - Parameter basePath: Path where all repositories are cloned
     /// - Returns: String with a relative path to requested repository
-    func path(repo identifier: String, basePath: String) -> String {
+    func sourcesPath(repo identifier: String, basePath: String) -> String {
         guard let repo = repositories[identifier] else {
             Console.fatalError("Unknown repository identifier `\(identifier)`.")
+        }
+        // In case that local files option is set, then return that path.
+        if let localPath = repo.localFiles {
+            return localPath
         }
         return basePath.addingPathComponent(repo.path ?? identifier)
     }

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -49,6 +49,16 @@ Prints embedded command's help to the console:
   - Tells `DocuCheck` to fetch changes only for required `repo`. Other repositories will be processed like with using `--fast` switch.
   - You can use this option for multiple repositories for the same command. 
 
+- `--test=path` or `-t path`
+  - Tells `DocuCheck` to use local path as a source for the repository. The repository identifier is determined from the last path component.
+  - In case that repository identifier cannot be determined from the last path component (e.g. you have cloned your sources on a custom path), then use `--testRepo` switch before `--test`
+  - You can use this option for multiple repositories for the same command.
+  - It's recommended to use `--fast` switch when you testing your locally changed documentation.
+
+- `--testRepo=repo` or `-tr repo`
+  - Tells `DocuCheck` to use `repo` as repository identifier for the subsequent `--test=path` option.
+  - This swith can be used only in combination with `--test` or `-t` option.
+
 - `--verbose` or `-v2`
   - Tells `DocuCheck` to print more debug information to the console.
   - You can use this switch in case of troubles, to investigate more about what's wrong.

--- a/docs/Writing-Wultras-Documentation.md
+++ b/docs/Writing-Wultras-Documentation.md
@@ -36,29 +36,14 @@ This document describes how to create a proper documentation for Wultra's applic
    - Let's say, you're going to update documentation for [`wultra/ssl-pinning-ios`](https://github.com/wultra/ssl-pinning-ios)
    - Let's say, you have cloned that repo into `/Users/johndoe/Dev/libs/ssl-pinning-ios`.
    - Create a new branch from current `develop` branch. For example `features/documentation-update`.
-   
-1. Add local path to DocuCheck's configuration:
-   - Edit `/Users/johndoe/Dev/docs/wultra-developers/releases/develop.json`
-   - Put `"localFiles"` key into the configuration. For example:
-     ```json
-     {
-         "repositories": {
-             "ssl-pinning-ios" : {
-                 "remote": "wultra/ssl-pinning-ios",
-                 "localFiles": "/Users/johndoe/Dev/libs/ssl-pinning-ios"
-             },
-         }
-     }
-     ```
 
-1. Run `./update-develop.sh --fast` every time you change documentation for `ssl-pinning-ios`
+1. Run `./update-develop.sh --fast -t /Users/johndoe/Dev/libs/ssl-pinning-ios` every time you change documentation for `ssl-pinning-ios`
 
 1. Optional but recommended, run `./run-local-server.sh` in another console
    - Test your changes live at `http://127.0.0.1:4000/docs/develop/` ([open link](http://127.0.0.1:4000/docs/develop/))
    - You can keep the local server up and running. It will reflect your changes automatically. Just wait a couple of seconds and then reload the page.
 
 1. After you're done with your changes, then:
-   - Revert the configuration you modified in step #3 
    - Push updated documentation into that `features/documentation-update` branch
    - Make a pull request with your changed documentation
    - Wait for a review...


### PR DESCRIPTION
- Added `--test` and `--testRepo` switches
- Improved performance when local files are used as a source for documentation
- Added missing informational logs in several docucheck steps