### PR TITLE
Fix #34: Allow trailing slash in --test path

### DIFF
--- a/Sources/DocuCheckLib/Utility/StringPathExtensions.swift
+++ b/Sources/DocuCheckLib/Utility/StringPathExtensions.swift
@@ -61,7 +61,7 @@ extension String {
             // forward slash not found
             return self
         }
-        return String(self[rpos.upperBound..<self.endIndex])
+        return String(self[rpos.upperBound..<stringEnd])
     }
     
     /// Returns directory part from path, stored in the string.


### PR DESCRIPTION
Fixes bug in helper function that must return a file item name without directory separator. For example:
- `/my/folder` must return `folder`
- `/my/folder/` must also return `folder` string